### PR TITLE
Updated extensions to include empty string.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -86,6 +86,6 @@ module.exports = {
         //tells webpack where to look for modules
         modules: ['node_modules'],
         //extensions that should be used to resolve modules
-        extensions: ['.js', '.jsx']
+        extensions: ['', '.js', '.jsx']
     }   
 };


### PR DESCRIPTION
I found this answer on [stack overflow](http://stackoverflow.com/questions/37015447/module-not-found-error-cannot-resolve-module-react-when-i-use-webpack). 

This would look for module in the order of `react.js`, `react.js.js` and `react.js.jsx`. This would address issue #5 